### PR TITLE
feat(quality): PHP-CS-Fixer, PHPStan, Prettier — Phase 0 #4

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -8,3 +8,7 @@
 /var/
 /vendor/
 ###< symfony/framework-bundle ###
+
+###> friendsofphp/php-cs-fixer ###
+/.php-cs-fixer.cache
+###< friendsofphp/php-cs-fixer ###

--- a/backend/.php-cs-fixer.php
+++ b/backend/.php-cs-fixer.php
@@ -1,0 +1,18 @@
+<?php
+
+$finder = PhpCsFixer\Finder::create()
+    ->in(__DIR__ . '/src')
+;
+
+return (new PhpCsFixer\Config())
+    ->setRules([
+        '@PSR12' => true,
+        '@Symfony' => true,
+        'array_syntax' => ['syntax' => 'short'],
+        'ordered_imports' => ['sort_algorithm' => 'alpha'],
+        'no_unused_imports' => true,
+        'trailing_comma_in_multiline' => true,
+        'phpdoc_order' => true,
+    ])
+    ->setFinder($finder)
+;

--- a/backend/composer.json
+++ b/backend/composer.json
@@ -22,6 +22,7 @@
     "config": {
         "allow-plugins": {
             "php-http/discovery": true,
+            "phpstan/extension-installer": true,
             "symfony/flex": true,
             "symfony/runtime": true
         },
@@ -60,7 +61,14 @@
         ],
         "post-update-cmd": [
             "@auto-scripts"
-        ]
+        ],
+        "lint": [
+            "@lint:cs",
+            "@lint:stan"
+        ],
+        "lint:cs": "vendor/bin/php-cs-fixer fix --dry-run --diff",
+        "lint:stan": "vendor/bin/phpstan analyse",
+        "fix:cs": "vendor/bin/php-cs-fixer fix"
     },
     "conflict": {
         "symfony/symfony": "*"
@@ -72,6 +80,10 @@
         }
     },
     "require-dev": {
+        "friendsofphp/php-cs-fixer": "^3.94",
+        "phpstan/extension-installer": "^1.4",
+        "phpstan/phpstan": "^2.1",
+        "phpstan/phpstan-symfony": "^2.0",
         "symfony/maker-bundle": "^1.67"
     }
 }

--- a/backend/phpstan.neon
+++ b/backend/phpstan.neon
@@ -1,0 +1,6 @@
+parameters:
+    level: 8
+    paths:
+        - src
+    symfony:
+        containerXmlPath: var/cache/dev/App_KernelDevDebugContainer.xml

--- a/frontend/.prettierrc
+++ b/frontend/.prettierrc
@@ -1,0 +1,6 @@
+{
+  "semi": false,
+  "singleQuote": true,
+  "tabWidth": 2,
+  "trailingComma": "all"
+}

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -3,6 +3,7 @@ import globals from 'globals'
 import reactHooks from 'eslint-plugin-react-hooks'
 import reactRefresh from 'eslint-plugin-react-refresh'
 import tseslint from 'typescript-eslint'
+import prettier from 'eslint-config-prettier'
 import { defineConfig, globalIgnores } from 'eslint/config'
 
 export default defineConfig([
@@ -14,6 +15,7 @@ export default defineConfig([
       tseslint.configs.recommended,
       reactHooks.configs.flat.recommended,
       reactRefresh.configs.vite,
+      prettier,
     ],
     languageOptions: {
       ecmaVersion: 2020,

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build",
-    "lint": "eslint .",
+    "lint": "eslint . && prettier --check src",
+    "format": "prettier --write src",
     "preview": "vite preview"
   },
   "dependencies": {
@@ -23,9 +24,11 @@
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.1",
     "eslint": "^9.39.4",
+    "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-react-hooks": "^7.0.1",
     "eslint-plugin-react-refresh": "^0.5.2",
     "globals": "^17.4.0",
+    "prettier": "^3.8.1",
     "tailwindcss": "^4.2.2",
     "typescript": "~6.0.2",
     "typescript-eslint": "^8.58.0",

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,1 +1,1 @@
-@import "tailwindcss";
+@import 'tailwindcss';


### PR DESCRIPTION
## Résumé

**Backend**
- PHP-CS-Fixer 3 (PSR-12 + règles Symfony)
- PHPStan niveau 8 avec extension Symfony
- Scripts : `composer lint` / `composer fix:cs`

**Frontend**
- Prettier configuré + intégré à ESLint
- Scripts : `npm run lint` / `npm run format`

## Test plan

- [x] `cd backend && composer lint` → 0 erreurs
- [x] `cd frontend && npm run lint` → 0 erreurs

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)