### PR TITLE
fix(ci): warm up Symfony cache before PHPStan

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,10 @@ jobs:
         working-directory: ./backend
         run: vendor/bin/php-cs-fixer fix --dry-run --diff
 
+      - name: Warm up Symfony cache
+        working-directory: ./backend
+        run: php bin/console cache:warmup --env=dev
+
       - name: Run PHPStan
         working-directory: ./backend
         run: vendor/bin/phpstan analyse


### PR DESCRIPTION
PHPStan-Symfony needs the compiled container XML to analyse services.